### PR TITLE
Add explanations and format as sections

### DIFF
--- a/adr_template_by_michael_nygard.md
+++ b/adr_template_by_michael_nygard.md
@@ -1,15 +1,24 @@
 # ADR template by Michael Nygard
 
-This is the template in [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+This is the template in [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+You can use [adr-tools](https://github.com/npryce/adr-tools) for managing the ADR files.
 
 In each ARD file, write these sections:
 
-* **Title**: short present tense imperative phrase, less than 50 characters, like a git commit message.
+# TITLE <short present tense imperative phrase, less than 50 characters, like a git commit message.>
 
-* **Status**: proposed, accepted, rejected, deprecated, superseded, etc.
+## Status
 
-* **Context**: what is the issue that we're seeing that is motivating this decision or change.
+<proposed, accepted, rejected, deprecated, superseded, etc.>
 
-* **Decision**: what is the change that we're actually proposing or doing.
+## Context
 
-* **Consequences**: what becomes easier or more difficult to do because of this change.
+<what is the issue that we're seeing that is motivating this decision or change.>
+
+## Decision
+
+<what is the change that we're actually proposing or doing.>
+
+## Consequences
+
+<what becomes easier or more difficult to do because of this change.>

--- a/adr_template_by_michael_nygard.md
+++ b/adr_template_by_michael_nygard.md
@@ -3,13 +3,13 @@
 This is the template in [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
 You can use [adr-tools](https://github.com/npryce/adr-tools) for managing the ADR files.
 
-In each ARD file, write these sections:
+In each ADR file, write these sections:
 
 # TITLE <short present tense imperative phrase, less than 50 characters, like a git commit message.>
 
 ## Status
 
-<proposed, accepted, rejected, deprecated, superseded, etc.>
+<proposed, accepted, rejected, deprecated, superseeded, etc.>
 
 ## Context
 


### PR DESCRIPTION
The [adr-tools](https://github.com/npryce/adr-tools) offer a [markdown template](https://github.com/npryce/adr-tools/blob/master/src/template.md) which uses sections.
In the text of this template, the word "sections" is also used.

So, I converted the single-line items into sections and kept the questions.

I used `<...>` to indicate place holders. This seems the common notation in Markdown files.