### PR TITLE
Use markdown heading and use markdown-toc to generate TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # Architecture Decision Record (ADR)
 
-* [Introduction](#introduction)
-* [ADR example templates](#adr-example-templates)
-* [How to start using ADRs](#how-to-start-using-adrs)
-* [How to start using ADRs with tools](#how-to-start-using-adrs-with-tools)
-* [How to start using ADRs with git](#how-to-start-using-adrs-with-git)
-* [ADR file name conventions](#adr-file-name-conventions)
-* [Contributing](#contributing)
-* [Sources](#sources)
+<!-- toc -->
 
+- [Introduction](#introduction)
+- [ADR example templates](#adr-example-templates)
+- [How to start using ADRs](#how-to-start-using-adrs)
+- [How to start using ADRs with tools](#how-to-start-using-adrs-with-tools)
+- [How to start using ADRs with git](#how-to-start-using-adrs-with-git)
+- [ADR file name conventions](#adr-file-name-conventions)
+- [Contributing](#contributing)
+- [Sources](#sources)
+  * [Introduction](#introduction-1)
+  * [Templates](#templates)
+  * [In-depth](#in-depth)
+  * [See also](#see-also)
 
-<h2><a name="introduction">Introduction</a></h2>
+<!-- tocstop -->
+
+## Introduction
 
 An architectural decision (AD) is a software design choice that addresses a significant requirement.
 
@@ -23,7 +30,7 @@ All these are within the topic of architectural knowledge management (AKM).
 The goal of this document is to provide a fast overview of ADRs, how to create them, and where to look for more information.
 
 
-<h2><a name="adr-example-templates">ADR example templates</a></h2>
+## ADR example templates
 
 ADR example templates that we have collected on the net:
 
@@ -34,7 +41,7 @@ ADR example templates that we have collected on the net:
 * [ADR template using Planguage](adr_template_using_planguage.md) (more quality assurance oriented)
 
 
-<h2><a name="how-to-start-using-adrs">How to start using ADRs</a></h2>
+## How to start using ADRs
 
 To start using ADRs, talk with your teammates about these areas.
 
@@ -68,7 +75,7 @@ To start using ADRs, talk with your teammates about these areas.
     * Hence, experiences with past decisions, both good and bad, can be valuable reusable assets when employing an explicit knowledge management strategy.
 
 
-<h2><a name="how-to-start-using-adrs-with-tools">How to start using ADRs with tools</a></h2>
+## How to start using ADRs with tools
 
 You can start using ADRs with tools any way you want.
 
@@ -83,7 +90,7 @@ For example:
   * If you like using wikis, such as MediaWiki, then you can create an ADR wiki.
 
 
-<h2><a name="how-to-start-using-adrs-with-git">How to start using ADRs with git</a></h2>
+## How to start using ADRs with git
 
 If you like using git version control, then here's how we like to start using ADRs with git for a typical software project with source code.
 
@@ -98,7 +105,7 @@ If you like using git version control, then here's how we like to start using AD
 3. Write anything you want in the ADR. See the templates in this repo for ideas.
 
 
-<h2><a name="adr-file-name-conventions">ADR file name conventions</a></h2>
+## ADR file name conventions
 
 If you choose to create your ADRs using typical text files, then you may want to come up with your own ADR file name convention.
 
@@ -122,26 +129,27 @@ Our file name convention:
 
   * The extension is markdown. This can be useful for easy formatting.
 
-<h2><a name="contributing">Contributing</a></h2>
+
+## Contributing
 
 Your comments and suggestions are welcome.
 
 You can open a GitHub issue, or create a pull request, or email joel@joelparkerhenderson.com.
 
 
-<h2><a name="sources">Sources</a></h2>
+## Sources
 
-Introduction:
+### Introduction
 
 * [Architectural Decision - Wikipedia](https://en.wikipedia.org/wiki/Architectural_decision)
 * [Architecturally significant requirements](https://en.wikipedia.org/wiki/Architecturally_significant_requirements)
 
-Templates:
+### Templates
 
 * [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
 * [Template for documenting architecture alternatives and decisions - Stack Overflow](http://stackoverflow.com/questions/7104735/template-for-documenting-architecture-alternatives-and-decisions)
 
-In-depth:
+### In-depth
 
 * [ADMentor XML project - GitHub](https://github.com/IFS-HSR/ADMentor)
 * [Architectural Decision Guidance across Projects: Problem Space Modeling, Decision Backlog Management and Cloud Computing Knowledge](https://www.ifs.hsr.ch/fileadmin/user_upload/customers/ifs.hsr.ch/Home/projekte/ADMentor-WICSA2015ubmissionv11nc.pdf)
@@ -150,7 +158,7 @@ In-depth:
 * [Architecture Decisions: Demystifying Architecture](https://www.utdallas.edu/~chung/SA/zz-Impreso-architecture_decisions-tyree-05.pdf)
 * [ThoughtWorks Technology Radar: Lightweight Architecture Decision Records](https://www.thoughtworks.com/radar/techniques/lightweight-architecture-decision-records)
 
-See also:
+### See also
 
 * REMAP (Representation and Maintenance of Process Knowledge)
 * DRL (Decision Representation Language)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,17 @@
 # Architecture Decision Record (ADR)
 
-<!-- toc -->
-
-- [Introduction](#introduction)
-- [ADR example templates](#adr-example-templates)
-- [How to start using ADRs](#how-to-start-using-adrs)
-- [How to start using ADRs with tools](#how-to-start-using-adrs-with-tools)
-- [How to start using ADRs with git](#how-to-start-using-adrs-with-git)
-- [ADR file name conventions](#adr-file-name-conventions)
-- [Contributing](#contributing)
-- [Sources](#sources)
+* [Introduction](#introduction)
+* [ADR example templates](#adr-example-templates)
+* [How to start using ADRs](#how-to-start-using-adrs)
+* [How to start using ADRs with tools](#how-to-start-using-adrs-with-tools)
+* [How to start using ADRs with git](#how-to-start-using-adrs-with-git)
+* [ADR file name conventions](#adr-file-name-conventions)
+* [Contributing](#contributing)
+* [Sources](#sources)
   * [Introduction](#introduction-1)
   * [Templates](#templates)
   * [In-depth](#in-depth)
   * [See also](#see-also)
-
-<!-- tocstop -->
 
 ## Introduction
 


### PR DESCRIPTION
The headings were typeset manually:

    <h2><a name="adr-example-templates">ADR example templates</a></h2>

This PR changes them to markdown headings:

    ## ADR example templates

By using [markdown-toc](https://www.npmjs.com/package/markdown-toc), the TOC is inserted manually.

I also added third-level headings to the sources sub sections - not sure if that is really OK.