### PR TITLE
Add Decision Reasoning Format (DRF) as related format

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,3 +545,5 @@ See also:
 - QOC (Questions, Options, and Criteria)
 
 - IBM’s e-Business Reference Architecture Framework
+
+- [Decision Reasoning Format (DRF)](https://github.com/reasoning-formats/reasoning-formats) - A vendor-neutral, machine-readable YAML/JSON format for representing decisions with explicit reasoning, assumptions, cognitive state, and trade-offs. Complements ADRs by adding structured, validatable reasoning to decision documentation.


### PR DESCRIPTION
## Summary

- Adds [Decision Reasoning Format (DRF)](https://github.com/reasoning-formats/reasoning-formats) to the "See also" section of the README as a related format.

## How DRF complements ADRs

ADRs document *what* was decided and *why* in prose form. DRF takes the same goal — documenting decisions — but adds a machine-readable, structured layer on top:

- **Reasoning patterns**: Explicit vocabulary for *how* a decision was reasoned (operational, risk-based, contrafactual, etc.)
- **Cognitive state**: Tracks the phase of reasoning (exploration, tension, convergence) and confidence level
- **Assumptions**: Structured capture of premises accepted during the decision, with confidence scores
- **Unresolved tensions**: Documents known trade-offs or risks that were accepted rather than resolved
- **Interventions**: Records the key questions and challenges that shaped the reasoning

DRF is designed as a complementary tool, not a replacement for ADRs. Teams can use ADRs for human-readable decision documentation while using DRF to add structured, validatable reasoning that can be consumed by automation and AI systems.

The format is vendor-neutral, domain-agnostic, and uses YAML/JSON — making it easy to integrate into existing ADR workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)