### PR TITLE
Add ADR-for-AI-development article to In-depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For example:
 
 - If you like using Google Drive and online editing, then you can create a Google Doc, or Google Sheet.
 
-- If you like use source code version control, such as git, then you can create a file for each ADR.
+- If you like using source code version control, such as git, then you can create a file for each ADR.
 
 - If you like using project planning tools, such as Atlassian Jira, then you can use the tool's planning tracker.
 
@@ -294,7 +294,7 @@ Example answer: We want to create an ADR when we want future developers to under
 
 ### What justifies not raising an ADR?
 
-Consider areas such as decisions that are not about architecture, or are tiny such as minimal-risk or self-contained or single-developer, or are already fully covered elsewhere such as by standards or policies or documentation, or are temporary such as workarounds or proofs of concepts or orexperiments.
+Consider areas such as decisions that are not about architecture, or are tiny such as minimal-risk or self-contained or single-developer, or are already fully covered elsewhere such as by standards or policies or documentation, or are temporary such as workarounds or proofs of concepts or or experiments.
 
 Example answer: We want to skip an ADR when a decision is limited in scope and time and risk and cost, or is already covered elsewhere.
 
@@ -337,7 +337,7 @@ Example answer: We use the leadership principles of bias for action, disagree-an
 
 [Arc42](https://arc42.org/) answers two questions in a pragmatic way and can be tailored to your specific needs. What should you document/communicate about your architecture? How should you document/communicate? Arc42 includes architecture decision records plus guidance on goals, constraints, contexts, quality, risks, and more.
 
-[The C4 model](https://c4model.com/) is an easy to learn, developer friendly approach to software architecture diagramming. C4 is a set of hierarchical digrams for context, containers, components, code, plus supporting diagrams for system landscape, dynamic, and deployment.
+[The C4 model](https://c4model.com/) is an easy to learn, developer friendly approach to software architecture diagramming. C4 is a set of hierarchical diagrams for context, containers, components, code, plus supporting diagrams for system landscape, dynamic, and deployment.
 
 </div>
 
@@ -432,7 +432,7 @@ This is a fitness function to evaluate if our work is
 using all our decisions, and is correct and accurate.
 
 - Our decisions are here: {url}
-- Our wor to evaluate is here: {url}
+- Our work to evaluate is here: {url}
 
 Explain any errors, problems, gaps, weaknesses. Be direct. Be decisive.
 ```

--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ In-depth:
 
 - [Solution Architecture Decisions - By Gareth Morgan](https://www.linkedin.com/pulse/solution-architecture-decisions-gareth-morgan-0r5xe/)
 
+- [What is an ADR? Why They're Critical for AI Development (outcomeops.ai)](https://www.outcomeops.ai/blogs/what-is-an-adr-and-why-theyre-critical-for-ai-powered-development)
+
 Tools:
 
 - [Command-line tools for working with Architecture Decision Records](https://github.com/npryce/adr-tools)


### PR DESCRIPTION
Adds a recent article on ADRs in the AI-assisted development era to the In-depth section. The post argues ADRs are now a load-bearing artifact for AI coding assistants they're the format that lets a model retrieve and apply architectural intent at decision time, rather than re-deriving it from code. Fits alongside the other practitioner perspectives in the section (ThoughtWorks Radar piece, InfoQ skeptic's guide, Olaf Zimmermann's "Architectural Decisions — The Making Of").
