### PR TITLE
docs(tyree-akerman): fix double space after Notes: in template

### DIFF
--- a/locales/en/templates/decision-record-template-by-jeff-tyree-and-art-akerman/index.md
+++ b/locales/en/templates/decision-record-template-by-jeff-tyree-and-art-akerman/index.md
@@ -28,5 +28,5 @@ This is the architecture decision description template published in ["Architectu
 
 * **Related principles**: If the enterprise has an agreed-upon set of principles, make sure the decision is consistent with one or more of them. This helps ensure alignment along domains or systems.
 
-* **Notes**:  Because the decision-making process can take weeks, we’ve found it useful to capture notes and issues that the team discusses during the socialization process.
+* **Notes**: Because the decision-making process can take weeks, we’ve found it useful to capture notes and issues that the team discusses during the socialization process.
 


### PR DESCRIPTION
Line 31 of `locales/en/templates/decision-record-template-by-jeff-tyree-and-art-akerman/index.md` has `* **Notes**:  Because` (two spaces after the colon). All other field bullets in the template use a single space (`* **Issue**:`, `* **Decision**:`, `* **Status**:`, `* **Group**:`, `* **Assumptions**:`, ..., `* **Related principles**:`). Normalize to single space for consistency.

Single-character change; no other content modified.