### PR TITLE
Add Mneme HQ to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ Tools:
 
 - [Decision Guardian](https://github.com/DecispherHQ/decision-guardian)
 
+- [Mneme HQ - ADR enforcement for AI coding agents](https://github.com/TheoV823/mneme)
+
 Company-Specific Guidance:
 
 - [Amazon: AWS Prescriptive Guidance: ADR Process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)


### PR DESCRIPTION
Closes #105.

Adds Mneme HQ to the **Tools** subsection of "For more information", as discussed in issue #105.

Mneme HQ is an open-source ADR enforcement layer that turns architectural decisions and project rules into deterministic checks for AI coding assistants.

Entry formatted to match the existing Tools section style: short link title, no trailing description, and the same hyphen separator pattern used by nearby entries.

Repo: https://github.com/TheoV823/mneme