### PR TITLE
Add template for Important Technical Decisions (ITDs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Templates:
 - [Decision record template by Olaf Zimmermann](https://medium.com/olzzio/y-statements-10eb07b5a177)
 - [Decision record template by Gareth Morgan](locales/en/templates/decision-record-template-by-gareth-morgan/)
 - [Decision record template by GIG Cymru NHS Wales](locales/en/templates/decision-record-template-by-gig-cymru-nhs-wales/)
+- [Decision record template for Important Technical Decisions (ITDs) by Ignacio Larrañaga](locales/en/templates/decision-record-template-for-important-technical-decisions/)
 - [Translations into more languages](locales/)
 
 Examples:
@@ -261,6 +262,8 @@ ADR example templates that we have collected on the net:
 - [ADR template of the Markdown Any Decision Records (MADR) project](locales/en/templates/decision-record-template-of-the-madr-project/) (both simple and elaborate version; the latter emphasizes options and their pros and cons)
 
 - [ADR template using Planguage](locales/en/templates/decision-record-template-using-planguage/) (more quality assurance oriented)
+
+- [Template for Important Technical Decisions (ITDs) by Ignacio Larrañaga](locales/en/templates/decision-record-template-for-important-technical-decisions/) (lean and decision-first, optimized for fast executive review)
 
 <div class="include" data-path="locales/en/documents/teamwork-advice-for-adrs">
 

--- a/locales/en/templates/decision-record-template-for-important-technical-decisions/LICENSE.md
+++ b/locales/en/templates/decision-record-template-for-important-technical-decisions/LICENSE.md
@@ -1,0 +1,12 @@
+# LICENSE
+
+This template is based on the "Important Technical Decisions (ITDs)" concept by
+Ignacio Larrañaga, described in this article:
+
+https://ignaciolarranaga.medium.com/itds-a-lean-adr-for-executive-technical-decision-making-at-scale-e18bb3f6a563
+
+The author, Ignacio Larrañaga, contributes this template to the repository and
+licenses it under
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/): to the extent
+possible under law, the author has waived all copyright and related or
+neighboring rights to this template.

--- a/locales/en/templates/decision-record-template-for-important-technical-decisions/README.md
+++ b/locales/en/templates/decision-record-template-for-important-technical-decisions/README.md
@@ -1,0 +1,36 @@
+# Decision record template for Important Technical Decisions (ITDs)
+
+This is the Important Technical Decisions (ITD) template described in
+[ITDs: a lean ADR for executive technical decision-making at scale - Ignacio Larrañaga](https://ignaciolarranaga.medium.com/itds-a-lean-adr-for-executive-technical-decision-making-at-scale-e18bb3f6a563).
+
+ITDs are a focused evolution of ADRs, optimized for speed, clarity, and
+executive validation. Where an ADR documents what was decided, an ITD is a
+lean, decision-first artifact that makes the decision itself reviewable, so
+stakeholders can scan it quickly and challenge it easily. ITDs are well suited
+to technical decisions that are not strictly architectural, such as choosing a
+model, a library, or a CI/CD strategy.
+
+In each ITD file, write these sections:
+
+# Title
+
+State the decision itself, not a description of the topic.
+For example, "Use Qwen2.5 1.5B Instruct for on-device translation".
+
+## The Problem
+
+One sentence stating what we are trying to solve.
+
+## Options Considered
+
+The alternatives that were on the table, with the selected option in **bold**.
+
+## Rationale
+
+Only the decisive factors that led to the choice, not an exhaustive list of
+every pro and con.
+
+## Notes
+
+Optional. Any additional context worth recording, such as constraints,
+assumptions, or links.

--- a/locales/en/templates/decision-record-template-for-important-technical-decisions/index.md
+++ b/locales/en/templates/decision-record-template-for-important-technical-decisions/index.md
@@ -1,0 +1,36 @@
+# Decision record template for Important Technical Decisions (ITDs)
+
+This is the Important Technical Decisions (ITD) template described in
+[ITDs: a lean ADR for executive technical decision-making at scale - Ignacio Larrañaga](https://ignaciolarranaga.medium.com/itds-a-lean-adr-for-executive-technical-decision-making-at-scale-e18bb3f6a563).
+
+ITDs are a focused evolution of ADRs, optimized for speed, clarity, and
+executive validation. Where an ADR documents what was decided, an ITD is a
+lean, decision-first artifact that makes the decision itself reviewable, so
+stakeholders can scan it quickly and challenge it easily. ITDs are well suited
+to technical decisions that are not strictly architectural, such as choosing a
+model, a library, or a CI/CD strategy.
+
+In each ITD file, write these sections:
+
+# Title
+
+State the decision itself, not a description of the topic.
+For example, "Use Qwen2.5 1.5B Instruct for on-device translation".
+
+## The Problem
+
+One sentence stating what we are trying to solve.
+
+## Options Considered
+
+The alternatives that were on the table, with the selected option in **bold**.
+
+## Rationale
+
+Only the decisive factors that led to the choice, not an exhaustive list of
+every pro and con.
+
+## Notes
+
+Optional. Any additional context worth recording, such as constraints,
+assumptions, or links.

--- a/locales/en/templates/index.md
+++ b/locales/en/templates/index.md
@@ -10,3 +10,4 @@
 * [Decision record template using Planguage](decision-record-template-using-planguage)
 * [Decision record template by Gareth Morgan](decision-record-template-by-gareth-morgan)
 * [Decision record template by GIG Cymru NHS Wales](locales/en/templates/decision-record-template-by-gig-cymru-nhs-wales/)
+* [Decision record template for Important Technical Decisions (ITDs) by Ignacio Larrañaga](decision-record-template-for-important-technical-decisions)


### PR DESCRIPTION
## What

Adds a new decision record template variant: **Important Technical Decisions (ITDs)** — a lean, decision-first evolution of the ADR, optimized for speed, clarity, and executive validation.

Where an ADR documents *what was decided*, an ITD makes the *decision itself* reviewable, so stakeholders can scan it quickly and challenge it easily. It suits technical decisions that aren't strictly architectural (e.g. choosing a model, a library, or a CI/CD strategy).

The template has four sections plus an optional one:

- **Title** — states the decision itself
- **The Problem** — one sentence on what we're solving
- **Options Considered** — alternatives, with the selected option in bold
- **Rationale** — only the decisive factors
- **Notes** (optional) — additional context

## Changes

- New template directory `locales/en/templates/decision-record-template-for-important-technical-decisions/` with `README.md`, `index.md`, and `LICENSE.md` (CC0), following the existing template conventions.
- Listed in the templates index (`locales/en/templates/index.md`) and in both template lists in the root `README.md`.

## Reference

Full write-up: [ITDs: a lean ADR for executive technical decision-making at scale](https://ignaciolarranaga.medium.com/itds-a-lean-adr-for-executive-technical-decision-making-at-scale-e18bb3f6a563)